### PR TITLE
Fix Design button not working on Break Types cards

### DIFF
--- a/Yuzu.Web/Pages/Settings/Sections/_BreakTypesPartial.cshtml
+++ b/Yuzu.Web/Pages/Settings/Sections/_BreakTypesPartial.cshtml
@@ -53,14 +53,14 @@
                     Edit
                 </button>
                 <!-- Design button -->
-                <button class="btn btn-sm btn-outline-secondary btn-design">
+                <a href="#" class="btn btn-sm btn-outline-secondary btn-design">
                     <i class="bx bx-palette fs-sm me-1"></i>
                     Design
                     @if (!Model.IsSubscribed)
                     {
                         @Html.Raw(ProFeatures.GetBadgeHtml("ms-1"))
                     }
-                </button>
+                </a>
                 <!-- Delete button (hidden by default for system break types) -->
                 <button class="btn btn-sm btn-outline-danger btn-delete d-none">
                     <i class="bx bx-trash-alt fs-sm me-1"></i>


### PR DESCRIPTION
## Summary
- Fixed bug where clicking the Design button on Break Types cards did nothing
- The issue was caused by using a `<button>` element instead of an `<a>` tag

## Changes Made
- Changed Design button from `<button>` to `<a href="#">` tag
- This allows the JavaScript code that sets `href` attributes to work correctly
- All styling and Bootstrap classes remain unchanged

## Technical Details
**Root cause**: The Design button was implemented as a `<button>` element, but the JavaScript code at `index.ts:213` was setting `href` attributes on it:
```typescript
cardDiv.find('.btn-design').attr('href', `/designer?id=${item.id}`);
```

Buttons don't support `href` navigation - only anchor (`<a>`) tags do. The fix preserves all styling while changing the underlying HTML element to properly support navigation.

## Test Plan
- [x] Click Design button for subscribed users - navigates to designer page
- [x] Click Design button for non-subscribed users - shows premium modal
- [x] Verify button styling remains unchanged
- [x] Verify button hover/active states work correctly

Fixes #36

🤖 Generated with [Claude Code](https://claude.com/claude-code)