### PR TITLE
Add scrollable canvas with fixed Full HD dimensions

### DIFF
--- a/Yuzu.Web/Pages/Designer.cshtml
+++ b/Yuzu.Web/Pages/Designer.cshtml
@@ -58,13 +58,16 @@
 		</div>
 	</div>
 
-	<div id="designer-canvas" class="canvas" role="main" tabindex="0" aria-label="Design Canvas" aria-description="Canvas area for designing layouts. Use arrow keys to navigate when elements are selected."
-		 @if (!string.IsNullOrEmpty(Model.BackgroundImageUrl))
-		 {
-			 <text>style="background-image: url('@Model.BackgroundImageUrl');"</text>
-		 }
-		 >
-		<!-- Widgets will be added here by JavaScript -->
+	<!-- Canvas container with scrolling -->
+	<div id="canvas-container" class="canvas-container">
+		<div id="designer-canvas" class="canvas" role="main" tabindex="0" aria-label="Design Canvas" aria-description="Canvas area for designing layouts. Use arrow keys to navigate when elements are selected."
+			 @if (!string.IsNullOrEmpty(Model.BackgroundImageUrl))
+			 {
+				 <text>style="background-image: url('@Model.BackgroundImageUrl');"</text>
+			 }
+			 >
+			<!-- Widgets will be added here by JavaScript -->
+		</div>
 	</div>
 
 	@* Debug Info Panel (bottom of canvas) - Only shown when debug setting is enabled *@

--- a/Yuzu.Web/wwwroot/css/designer/designer.css
+++ b/Yuzu.Web/wwwroot/css/designer/designer.css
@@ -10,15 +10,27 @@ body {
     padding: 0;
 }
 
-/* Canvas styles */
+/* Canvas container with scrolling */
+.canvas-container {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100vw;
+    height: 100vh;
+    overflow: auto;
+    background-color: #2a2a2a;
+}
+
+/* Canvas styles - Fixed Full HD dimensions */
 .canvas {
     position: relative;
-    width: 100vw;
-    height: calc(100vh);
+    width: 1920px;
+    height: 1080px;
     background-color: #fafafa;
     overflow: hidden;
     background-position: center;
     background-size: cover;
+    margin: 0 auto;
 }
 
 /* Grid overlay that can be toggled */
@@ -51,7 +63,7 @@ body {
     display: flex;
     flex-direction: column; /* Ensure vertical stacking */
     user-select: none;
-    position: absolute;
+    position: fixed;
     z-index: 1000;
     padding: 0;
     width: max-content; /* Ensure the width is determined by the content */
@@ -170,7 +182,7 @@ body {
 
 /* Properties Toolbox Styling */
 .properties-toolbar {
-    position: absolute;
+    position: fixed;
     background-color: #f8f9fa;
     border: 1px solid #dee2e6;
     border-radius: 0.25rem;


### PR DESCRIPTION
## Summary
- Implements fixed 1920×1080 canvas with scrollable viewport
- Ensures consistent design experience across different screen sizes
- Canvas remains at Full HD resolution regardless of browser window size

## Changes
- Wrapped canvas in scrollable container div (`canvas-container`)
- Set canvas to fixed Full HD (1920×1080) dimensions
- Changed toolbars from `absolute` to `fixed` positioning to remain visible when scrolling
- Added dark gray background (`#2a2a2a`) outside canvas for clear visual boundaries
- Pointer events work correctly using `getBoundingClientRect()` which accounts for scroll offset

## Technical Details
- Canvas is centered with `margin: 0 auto`
- Container uses `overflow: auto` for scrollbars when needed
- All UI elements (toolbars, buttons, debug panel) stay fixed in viewport
- No JavaScript changes required - existing event handling works seamlessly

## Test Plan
- [x] Build completes successfully
- [x] Canvas displays at exactly 1920×1080
- [x] Scrollbars appear when browser window is smaller than Full HD
- [x] Widget interactions (click, drag, resize) work correctly
- [x] Toolbars remain visible when scrolling
- [x] Debug panel (if enabled) remains visible

Fixes #53

🤖 Generated with [Claude Code](https://claude.com/claude-code)